### PR TITLE
Initial travis/coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+  - node_modules
+notifications:
+  email: false
+  irc:
+    use_notice: true
+    skip_join: true
+    channels:
+      secure: PvfRuDS/xREWahkngXhs63AwARz3J8zSvlhDT3uV0n1fHbaU/4VkAzv6MgHOQBQllNYBhPayGflcF77YRUxrATaSMDntElcSDSGsCCqO3oSPHOsQ3b7Tzkz0W/qcYkwCC4CuuOFTbA2+Uo26K0Y5KxPSfT0opyViFA7+uxa+3qpwQC3EtkUVtRntvumVuPKJLFGqoPd1Xz6U7ML8N63lZl/tCb5pc/j7gBBWjZX0GCoOMK5wEycFhAnDbZiypkUuD8tP/uHk4S7Y22ahORgITKLup+KIF9jEkyJR/f+mhjCYH/9Dilrxj9JIchs4PSiq3DDAHHsm4w/l9HW9LMO3Jep2RtDcIQVMAY15eVG1ih0DqT78uo2d3BggijVZH9nGh5eSevB1rpL2yDUd7Yd5msAZxak8VbUZP2hlCsOhrKeZzfY6BSI3V98jr2vuXImO7t1ouyXkC0TGJmtGBJSAVxZxbK3IcAlTIuza0QtbEXsPGtTOymsVXpFw9zx8SpDnNKeo8z4CZCGg6uLdUxSB3wWKCRwyQTE45iYA4LOgRycXVpWabuSN9AClk2P/82/64jjzVUgVzmTCcFk0v2uqp4By+3lEUQKp3w1mTUrkjTj3npRI10DX2Qpk4dRXZRiaYcFHHmptD/1qEtKpqrXi+lnsiaIa5WnEZTv6BTWS5C0=
+node_js:
+- '6'
+- '5'
+- '4'
+- iojs-v3
+- iojs-v2
+- iojs-v1
+- '0.12'
+- '0.11'
+- '0.10'
+before_install:
+- npm i -g npm@^2.0.0
+before_script:
+- npm prune
+- export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
+after_success:
+- npm run coverage
+- npm run coverage:upload
+- curl -Lo travis_after_all.py https://git.io/travis_after_all
+- python travis_after_all.py
+- export $(cat .to_export_back) &> /dev/null
+branches:
+  except:
+  - /^v\d+\.\d+\.\d+$/

--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ class Scanner {
   run (url, cb) {
     this.url = url
     this.cb = cb
-    process.on('uncaughtException', function (err) {
+    process.on('uncaughtException', /* istanbul ignore next */ function (err) {
       console.error(err)
       app.exit(1)
     })
-    app.once('ready', () => this.onReady())
+    app.once('ready', /* istanbul ignore next */ () => this.onReady())
   }
 
   onReady () {
@@ -32,6 +32,7 @@ class Scanner {
 
   scanPage (error) {
     // Do the scan here, HTML source is in this.filename
+    // istanbul ignore else
     if (this.cb) {
       this.cb(error) // Assume caller will quit the app.
     } else {
@@ -45,6 +46,7 @@ class Scanner {
   }
 }
 
+// istanbul ignore if
 if (!module.parent || module.parent.id === '.') {
   const argv = yargs
         .usage('Usage: $0 URL')

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "electron-mocha",
     "testmon": "nodemon --exec '(electron-mocha && growlnotify -n nodemon --image ~/green.png -m good) || (growlnotify -n nodemon --image ~/red.png -m crash && exit 1)'",
-    "coverage": "electron-mocha --require test/coverage && istanbul report lcov"
+    "coverage": "electron-mocha --require test/coverage && istanbul report lcov",
+    "coverage:upload": "cat ./coverage/lcov.info | coveralls"
   },
   "bin": {
     "scan": "./bin/scan"
@@ -18,9 +19,11 @@
     "coveralls": "^2.11.9",
     "electron-mocha": "^2.3.0",
     "express": "^4.14.0",
+    "glob": "^7.0.5",
     "istanbul": "^0.4.4",
     "mocha": "^2.5.3",
-    "nodemon": "^1.9.2"
+    "nodemon": "^1.9.2",
+    "sinon": "^1.17.4"
   },
   "dependencies": {
     "electron-prebuilt": "^1.2.6",


### PR DESCRIPTION
Don't build vN.N.N (release) branches. Only notify after all bits of a matrix build.

The notification goes to the IRC channel as a notice from off-channel. +n needs to be set to allow that.

The istanbul ignores are allowing for 100% coverage to be reported. I've only used them where automated testing would be very difficult.

This also adds the glob and sinon modules that are necessary for tests to work properly.
